### PR TITLE
Closes #5

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,14 @@ import PRestApi from '@postgresrest/node';
 const cli = new PRestApi('myhost');
 ```
 
+or if you want you can use custom fetcher with any fetch tool you'd like:
+
+```typescript
+import axios from 'axios';
+
+const fetcher = (uri, method) => axios[method](uri).then(({data}) => data);
+const cli = new PRestApi('myhost', fetcher);
+```
 
 -------------------
 

--- a/jest.config.json
+++ b/jest.config.json
@@ -19,5 +19,8 @@
   },
   "transform": {
     "^.+\\.ts$": "babel-jest"
-  }
+  },
+  "setupFiles": [
+    "./tests/unit/setupJest.ts"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -28,11 +28,10 @@
     "eslint-config-prettier": "^6.11.0",
     "eslint-plugin-prettier": "^3.1.4",
     "jest": "^26.4.2",
+    "jest-fetch-mock": "^3.0.3",
     "prettier": "^2.1.1",
     "typedoc": "^0.19.1",
     "typescript": "^4.0.2"
   },
-  "dependencies": {
-    "axios": "^0.20.0"
-  }
+  "dependencies": {}
 }

--- a/src/entity/Request.ts
+++ b/src/entity/Request.ts
@@ -1,14 +1,19 @@
-import axios, { Method } from 'axios';
+type fetcherFn = <T>(uri: string, method: string) => Promise<T>;
+
+const defaultFetcher: fetcherFn = (uri, method) => fetch(uri, { method }).then((res) => res.json());
 
 export class Request {
   protected baseUrl: string;
 
-  constructor(baseUrl: string) {
+  protected fetcher: fetcherFn;
+
+  constructor(baseUrl: string, fetcher?: fetcherFn) {
     this.baseUrl = baseUrl;
+    this.fetcher = fetcher || defaultFetcher;
   }
 
-  public call<T>(method: Method, path: string): Promise<T> {
-    return axios[method](this.baseUrl + path).then(({ data }) => data);
+  public call<T>(method: string, path: string): Promise<T> {
+    return this.fetcher<T>(this.baseUrl + path, method);
   }
 }
 

--- a/tests/unit/entity/Request.spec.ts
+++ b/tests/unit/entity/Request.spec.ts
@@ -1,19 +1,19 @@
-jest.mock('axios');
 
+import fetchMock from "jest-fetch-mock"
 import Request from '~/entity/Request';
-import axios from 'axios';
 
 describe('entity/Request', () => {
   it('should execute call and get the response', async () => {
     const data = 'foo';
     const baseUrl = 'bar';
-    (axios.get as jest.Mock).mockResolvedValue({ data });
+    const method = 'get';
+    fetchMock.mockResolvedValue(new Response(JSON.stringify(data)));
 
     const req = new Request(baseUrl);
-    const resp = await req.call('get', '');
+    const resp = await req.call(method, '');
 
     expect(resp).toBe(data);
-    expect(axios.get).toHaveBeenCalledTimes(1);
-    expect(axios.get).toHaveBeenCalledWith(baseUrl);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith(baseUrl, { method });
   });
 });

--- a/tests/unit/entity/Request.spec.ts
+++ b/tests/unit/entity/Request.spec.ts
@@ -1,5 +1,4 @@
-
-import fetchMock from "jest-fetch-mock"
+import fetchMock from 'jest-fetch-mock';
 import Request from '~/entity/Request';
 
 describe('entity/Request', () => {

--- a/tests/unit/setupJest.ts
+++ b/tests/unit/setupJest.ts
@@ -1,0 +1,1 @@
+require('jest-fetch-mock').enableMocks()

--- a/tests/unit/setupJest.ts
+++ b/tests/unit/setupJest.ts
@@ -1,1 +1,2 @@
-require('jest-fetch-mock').enableMocks()
+import { enableFetchMocks } from 'jest-fetch-mock';
+enableFetchMocks();

--- a/yarn.lock
+++ b/yarn.lock
@@ -1505,13 +1505,6 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.10.1.tgz#e1e82e4f3e999e2cfd61b161280d16a111f86428"
   integrity sha512-zg7Hz2k5lI8kb7U32998pRRFin7zJlkfezGJjUc2heaD4Pw2wObakCDVzkKztTm/Ln7eiVvYsjqak0Ed4LkMDA==
 
-axios@^0.20.0:
-  version "0.20.0"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.20.0.tgz#057ba30f04884694993a8cd07fa394cff11c50bd"
-  integrity sha512-ANA4rr2BDcmmAQLOKft2fufrtuvlqR+cXNNinUmvfeSNCOF98PZL+7M/v1zIdGo7OLjEA9J2gXJL+j4zGsl0bA==
-  dependencies:
-    follow-redirects "^1.10.0"
-
 babel-jest@^26.3.0:
   version "26.3.0"
   resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-26.3.0.tgz#10d0ca4b529ca3e7d1417855ef7d7bd6fc0c3463"
@@ -1889,6 +1882,13 @@ core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
   integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
+
+cross-fetch@^3.0.4:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.0.6.tgz#3a4040bc8941e653e0e9cf17f29ebcd177d3365c"
+  integrity sha512-KBPUbqgFjzWlVcURG+Svp9TlhA5uliYtiNx/0r8nv0pdypeQCRJ9IaSIc3q/x3q8t3F75cHuwxVql1HFGHCNJQ==
+  dependencies:
+    node-fetch "2.6.1"
 
 cross-spawn@^6.0.0:
   version "6.0.5"
@@ -2456,11 +2456,6 @@ flatted@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.2.tgz#4575b21e2bcee7434aa9be662f4b7b5f9c2b5138"
   integrity sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==
-
-follow-redirects@^1.10.0:
-  version "1.13.0"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.13.0.tgz#b42e8d93a2a7eea5ed88633676d6597bc8e384db"
-  integrity sha512-aq6gF1BEKje4a9i9+5jimNFIpq4Q1WiwBToeRK5NvZBd/TRsmW8BsJfOEGkr76TbOyPVD3OVDN910EcUNtRYEA==
 
 for-in@^1.0.2:
   version "1.0.2"
@@ -3168,6 +3163,14 @@ jest-environment-node@^26.3.0:
     jest-mock "^26.3.0"
     jest-util "^26.3.0"
 
+jest-fetch-mock@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/jest-fetch-mock/-/jest-fetch-mock-3.0.3.tgz#31749c456ae27b8919d69824f1c2bd85fe0a1f3b"
+  integrity sha512-Ux1nWprtLrdrH4XwE7O7InRY6psIi3GOsqNESJgMJ+M5cv4A8Lh7SN9d2V2kKRZ8ebAfcd1LNyZguAOb6JiDqw==
+  dependencies:
+    cross-fetch "^3.0.4"
+    promise-polyfill "^8.1.3"
+
 jest-get-type@^25.2.6:
   version "25.2.6"
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-25.2.6.tgz#0b0a32fab8908b44d508be81681487dbabb8d877"
@@ -3807,6 +3810,11 @@ nice-try@^1.0.4:
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
+node-fetch@2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
+  integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
+
 node-int64@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"
@@ -4132,6 +4140,11 @@ progress@^2.0.0, progress@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
+
+promise-polyfill@^8.1.3:
+  version "8.1.3"
+  resolved "https://registry.yarnpkg.com/promise-polyfill/-/promise-polyfill-8.1.3.tgz#8c99b3cf53f3a91c68226ffde7bde81d7f904116"
+  integrity sha512-MG5r82wBzh7pSKDRa9y+vllNHz3e3d4CNj1PQE4BQYxLme0gKYYBm9YENq+UkEikyZ0XbiGWxYlVw3Rl9O/U8g==
 
 prompts@^2.0.1:
   version "2.3.2"


### PR DESCRIPTION
So what I've done is I removed axios at all from code, tests and dependencies.

One problem I've had is that Request types does not define Method types and just goes with string type, so I left it as string.

I've could have left axios as a default fetcher and as a peer dependency, but as far as I know the only bundler doing tree-shaking right is rollup, so others might have problems with axios still appearing in the bundle, but I might be wrong.