### PR TITLE
Add methods to Follow CRUD api

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,29 @@ Usage sample:
 const data = await cli.tableConnection('db', 'schema', 'table').query();
 ```
 
+### create
+It will reflect `/DATABASE/SCHEMA/TABLE` prest endpoint with `POST` method
 
+Usage sample:
+```typescript
+const data = await cli.tableConnection('db', 'schema', 'table').create({ foo: 'bar' });
+```
+
+### update
+It will reflect `/DATABASE/SCHEMA/TABLE` prest endpoint with `PATCH` method
+
+Usage sample:
+```typescript
+const data = await cli.tableConnection('db', 'schema', 'table').update('myid', { foo: 'fizz' });
+```
+
+### delete
+It will reflect `/DATABASE/SCHEMA/TABLE` prest endpoint with `DELETE` method
+
+Usage sample:
+```typescript
+const data = await cli.tableConnection('db', 'schema', 'table').delete('myid');
+```
 
 -------------------
 

--- a/package.json
+++ b/package.json
@@ -33,5 +33,7 @@
     "typedoc": "^0.19.1",
     "typescript": "^4.0.2"
   },
-  "dependencies": {}
+  "dependencies": {
+    "node-fetch": "^2.6.1"
+  }
 }

--- a/src/entity/Request.ts
+++ b/src/entity/Request.ts
@@ -1,6 +1,16 @@
-type fetcherFn = <T>(uri: string, method: string) => Promise<T>;
+import fetch from 'node-fetch';
 
-const defaultFetcher: fetcherFn = (uri, method) => fetch(uri, { method }).then((res) => res.json());
+type fetcherFn = <T>(uri: string, method: string, data?: T | Partial<T>) => Promise<T>;
+
+const defaultFetcher: fetcherFn = (uri, method, data) => {
+  const opts = {
+    method,
+    headers: { 'Content-Type': 'application/json' },
+    ...(!data ? {} : { body: JSON.stringify(data) }),
+  };
+
+  return fetch(uri, opts).then((res) => res.json());
+};
 
 export class Request {
   protected baseUrl: string;
@@ -12,8 +22,8 @@ export class Request {
     this.fetcher = fetcher || defaultFetcher;
   }
 
-  public call<T>(method: string, path: string): Promise<T> {
-    return this.fetcher<T>(this.baseUrl + path, method);
+  public call<T>(method: string, path: string, data?: T | Partial<T>): Promise<T> {
+    return this.fetcher<T>(this.baseUrl + path, method, data);
   }
 }
 

--- a/src/entity/TableConnector.ts
+++ b/src/entity/TableConnector.ts
@@ -1,15 +1,32 @@
 import Request from './Request';
 
+const DEFAULT_COLUMN_ID = 'id';
+type MultipleId = string | number;
+
 export class TableConnector<T> extends Request {
+  private idColumn: MultipleId;
   private dbPath: string;
 
-  constructor(baseUrl: string, dbPath: string) {
+  constructor(baseUrl: string, dbPath: string, idColumn: MultipleId = DEFAULT_COLUMN_ID) {
     super(baseUrl);
     this.dbPath = dbPath;
+    this.idColumn = idColumn;
   }
 
   query(): Promise<T[]> {
     return this.call('get', this.dbPath);
+  }
+
+  create(data: T): Promise<T> {
+    return this.call('post', this.dbPath, data);
+  }
+
+  update(id: MultipleId, data: Partial<T>): Promise<T> {
+    return this.call('patch', `${this.dbPath}?${this.idColumn}=${id}`, data);
+  }
+
+  delete(id: MultipleId): Promise<T> {
+    return this.call('delete', `${this.dbPath}?${this.idColumn}=${id}`);
   }
 }
 

--- a/tests/unit/entity/Request.spec.ts
+++ b/tests/unit/entity/Request.spec.ts
@@ -2,17 +2,36 @@ import fetchMock from 'jest-fetch-mock';
 import Request from '~/entity/Request';
 
 describe('entity/Request', () => {
-  it('should execute call and get the response', async () => {
-    const data = 'foo';
-    const baseUrl = 'bar';
-    const method = 'get';
-    fetchMock.mockResolvedValue(new Response(JSON.stringify(data)));
+  const headers = { 'Content-Type': 'application/json' };
+  const data = 'foo';
+  const baseUrl = 'bar';
+  const method = 'get';
 
+  beforeEach(() => {
+    fetchMock.mockResolvedValue(new Response(JSON.stringify(data)));
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('should execute call and get the response without data', async () => {
     const req = new Request(baseUrl);
     const resp = await req.call(method, '');
 
     expect(resp).toBe(data);
     expect(fetchMock).toHaveBeenCalledTimes(1);
-    expect(fetchMock).toHaveBeenCalledWith(baseUrl, { method });
+    expect(fetchMock).toHaveBeenCalledWith(baseUrl, { method, headers });
+  });
+
+  it('should execute call and get the response with data', async () => {
+    const fakeBody = { foo: 'bar' };
+    const req = new Request(baseUrl);
+    const resp = await req.call(method, '', fakeBody);
+
+    const body = JSON.stringify(fakeBody);
+    expect(resp).toBe(data);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith(baseUrl, { method, headers, body });
   });
 });

--- a/tests/unit/entity/TableConnector.spec.ts
+++ b/tests/unit/entity/TableConnector.spec.ts
@@ -5,6 +5,8 @@ describe('entity/TableConnector', () => {
   const dbPath = '/prest/public/foo';
   const conn = new TableConnector(baseUrl, dbPath);
   const fakeResponse = 'foo';
+  const fakeData = { foo: 'bar' };
+  const fakeId = 'abc';
 
   beforeEach(() => {
     conn.call = jest.fn().mockReturnValue(fakeResponse);
@@ -20,5 +22,29 @@ describe('entity/TableConnector', () => {
     expect(resp).toBe(fakeResponse);
     expect(conn.call).toHaveBeenCalledTimes(1);
     expect(conn.call).toHaveBeenCalledWith('get', dbPath);
+  });
+
+  it('should execute .create() correctly', async () => {
+    const resp = await conn.create(fakeData);
+
+    expect(resp).toBe(fakeResponse);
+    expect(conn.call).toHaveBeenCalledTimes(1);
+    expect(conn.call).toHaveBeenCalledWith('post', dbPath, fakeData);
+  });
+
+  it('should execute .update() correctly', async () => {
+    const resp = await conn.update(fakeId, fakeData);
+
+    expect(resp).toBe(fakeResponse);
+    expect(conn.call).toHaveBeenCalledTimes(1);
+    expect(conn.call).toHaveBeenCalledWith('patch', `${dbPath}?id=${fakeId}`, fakeData);
+  });
+
+  it('should execute .delete() correctly', async () => {
+    const resp = await conn.delete(fakeId);
+
+    expect(resp).toBe(fakeResponse);
+    expect(conn.call).toHaveBeenCalledTimes(1);
+    expect(conn.call).toHaveBeenCalledWith('delete', `${dbPath}?id=${fakeId}`);
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3810,7 +3810,7 @@ nice-try@^1.0.4:
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
-node-fetch@2.6.1:
+node-fetch@2.6.1, node-fetch@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==


### PR DESCRIPTION
## Motivation
TableConnector have only the `.query` method. In this PR I created the API for post, patch and delete methods.

PS: That's a initial approach (I will enhance it when #2 comes)